### PR TITLE
✨ refactor : Optimizations

### DIFF
--- a/clients/besu.yml
+++ b/clients/besu.yml
@@ -1,0 +1,19 @@
+services:
+  node:
+    image: hyperledger/besu:latest
+
+    environment:
+      RUN_COMMAND: |
+        besu  --discovery-enabled=false \
+              --data-path=/data \
+              --genesis-file=/config/genesis.json \
+              --rpc-http-enabled=true \
+              --rpc-http-host=0.0.0.0 \
+              --engine-rpc-port=8551 \
+              --engine-host-allowlist="*" \
+              --engine-jwt-secret=/config/jwt.hex
+
+    extends:
+      file: ../config/docker/common.yml
+      service: base_client
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]

--- a/clients/erigon.yml
+++ b/clients/erigon.yml
@@ -1,5 +1,5 @@
 services:
-  erigon:
+  node:
     image: erigontech/erigon:latest
     # TODO: Remove root
     user: "root:root"

--- a/clients/geth.yml
+++ b/clients/geth.yml
@@ -1,5 +1,5 @@
 services:
-  geth:
+  node:
     image: ethereum/client-go:latest
 
     environment:

--- a/clients/nethermind.yml
+++ b/clients/nethermind.yml
@@ -1,0 +1,24 @@
+services:
+  node:
+    image: nethermind/nethermind:latest
+
+    environment:
+      RUN_COMMAND: |
+        ./nethermind --config=holesky \
+                    --Init.ChainSpecPath=/config/chainspec.json \
+                    --data-dir=/data \
+                    --Sync.NetworkingEnabled=false \
+                    --JsonRpc.Enabled=true \
+                    --JsonRpc.Host=0.0.0.0 \
+                    --HealthChecks.Enabled=true \
+                    --JsonRpc.EngineHost=0.0.0.0 \
+                    --JsonRpc.EnginePort=8551 \
+                    --JsonRpc.JwtSecretFile=/config/jwt.hex\
+                    --Init.GenesisHash=0x9cbea0de83b440f4462c8280a4b0b4590cdb452069757e2c510cb3456b6c98cc \
+                    --Sync.MaxAttemptsToUpdatePivot=0 \
+                    --log=INFO
+
+    extends:
+      file: ../config/docker/common.yml
+      service: base_client
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]

--- a/clients/reth.yml
+++ b/clients/reth.yml
@@ -1,5 +1,5 @@
 services:
-  reth:
+  node:
     # TODO: gchr.io would soon be deprecated
     # Read: https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr
     image: ghcr.io/paradigmxyz/reth:latest

--- a/config/chainspec.json
+++ b/config/chainspec.json
@@ -1,24 +1,78 @@
 {
-  "config": {
-    "chainId": 17000,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "berlinBlock": 0,
-    "londonBlock": 0,
-    "mergeNetsplitBlock": 0,
-    "terminalTotalDifficulty": 0,
-    "terminalTotalDifficultyPassed": true,
-    "shanghaiTime": 0,
-    "cancunTime": 0,
-    "ethash": {}
+  "name": "Holesky Testnet",
+  "dataDir": "holesky",
+  "engine": {
+    "Ethash": {}
   },
-  "alloc": {
+  "params": {
+    "accountStartNonce": "0x0",
+    "chainID": "0x4268",
+    "networkID": "0x4268",
+    "eip140Transition": "0x0",
+    "eip145Transition": "0x0",
+    "eip150Transition": "0x0",
+    "eip155Transition": "0x0",
+    "eip160Transition": "0x0",
+    "eip161abcTransition": "0x0",
+    "eip161dTransition": "0x0",
+    "eip211Transition": "0x0",
+    "eip214Transition": "0x0",
+    "eip658Transition": "0x0",
+    "eip1014Transition": "0x0",
+    "eip1052Transition": "0x0",
+    "eip1283Transition": "0x0",
+    "eip1283DisableTransition": "0x0",
+    "eip152Transition": "0x0",
+    "eip1108Transition": "0x0",
+    "eip1344Transition": "0x0",
+    "eip1884Transition": "0x0",
+    "eip2028Transition": "0x0",
+    "eip2200Transition": "0x0",
+    "eip2565Transition": "0x0",
+    "eip2929Transition": "0x0",
+    "eip2930Transition": "0x0",
+    "eip1559Transition": "0x0",
+    "eip3198Transition": "0x0",
+    "eip3529Transition": "0x0",
+    "eip3541Transition": "0x0",
+    "eip3651TransitionTimestamp": "0x0",
+    "eip3855TransitionTimestamp": "0x0",
+    "eip3860TransitionTimestamp": "0x0",
+    "eip4895TransitionTimestamp": "0x0",
+    "eip1153TransitionTimestamp": "0x0",
+    "eip4788TransitionTimestamp": "0x0",
+    "eip4844TransitionTimestamp": "0x0",
+    "eip5656TransitionTimestamp": "0x0",
+    "eip6780TransitionTimestamp": "0x0",
+    "terminalTotalDifficulty": "0x0",
+    "gasLimitBoundDivisor": "0x400",
+    "maxCodeSize": "0x6000",
+    "maxCodeSizeTransition": "0x0",
+    "maximumExtraDataSize": "0xffff",
+    "minGasLimit": "0x1388",
+    "registrar": "0x0000000000000000000000000000000000000000",
+    "MergeForkIdTransition": "0x0"
+  },
+  "genesis": {
+    "seal": {
+      "ethereum": {
+        "nonce": "0x1234",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    "difficulty": "0x01",
+    "baseFeePerGas": "0x7",
+    "author": "0x0000000000000000000000000000000000000000",
+    "extraData": "",
+    "gasLimit": "0x5D21DBA00",
+    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "timestamp": "0x65156994"
+  },
+  "nodes": [
+    "enode://ac906289e4b7f12df423d654c5a962b6ebe5b3a74cc9e06292a85221f9a64a6f1cfdd6b714ed6dacef51578f92b34c60ee91e9ede9c7f8fadc4d347326d95e2b@146.190.13.128:30303",
+    "enode://a3435a0155a3e837c02f5e7f5662a2f1fbc25b48e4dc232016e1c51b544cb5b4510ef633ea3278c0e970fa8ad8141e2d4d0f9f95456c537ff05fdf9b31c15072@178.128.136.233:30303"
+  ],
+  "accounts": {
     "0x0000000000000000000000000000000000000000": {
       "balance": "1"
     },
@@ -1004,14 +1058,5 @@
     "0x4BC656B34De23896fa6069C9862F355b740401aF": {
       "balance": "0x084595161401484a000000"
     }
-  },
-  "coinbase": "0x0000000000000000000000000000000000000000",
-  "difficulty": "0x01",
-  "baseFeePerGas": "0x7",
-  "extraData": "",
-  "gasLimit": "0x5d21dba00",
-  "nonce": "0x1234",
-  "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "timestamp": "0x65156994"
+  }
 }

--- a/config/docker/common.yml
+++ b/config/docker/common.yml
@@ -9,3 +9,4 @@ services:
       - ./entrypoint.sh:/entrypoint.sh
       - ../jwt.hex:/config/jwt.hex
       - ../genesis.json:/config/genesis.json
+      - ../chainspec.json:/config/chainspec.json

--- a/profiler/src/docker.rs
+++ b/profiler/src/docker.rs
@@ -35,21 +35,33 @@ impl DockerCompose {
 
         match output {
             Ok(output) => {
-                if !output.status.success() {
-                    let error_message = format!(
-                        "{} | stdout: {}",
-                        String::from_utf8_lossy(&output.stderr).trim(),
+                // Format docker output with emojis
+                if !output.stdout.is_empty() {
+                    println!(
+                        "🔵 Docker: {}",
                         String::from_utf8_lossy(&output.stdout).trim()
                     );
-                    // Print the error and exit
+                }
+                if !output.stderr.is_empty() {
+                    let stderr_str = String::from_utf8_lossy(&output.stderr);
+                    let stderr_trimmed = stderr_str.trim();
+                    if stderr_trimmed.contains("error") {
+                        eprintln!("❌ Docker Error: {}", stderr_trimmed);
+                    } else {
+                        println!("ℹ️  Docker: {}", stderr_trimmed);
+                    }
+                }
+
+                if !output.status.success() {
+                    let error_message =
+                        format!("❌ Docker command failed with status {}", output.status);
                     eprintln!("{}", error_message);
                     exit(1);
                 }
                 Ok(output)
             }
             Err(e) => {
-                let error_message = format!("Error executing docker command: {}", e);
-                // Print the error and exit
+                let error_message = format!("❌ Error executing docker command: {}", e);
                 eprintln!("{}", error_message);
                 exit(1);
             }

--- a/profiler/src/kute.rs
+++ b/profiler/src/kute.rs
@@ -6,10 +6,7 @@ use sha2::Sha256;
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
-use crate::{
-    bench_summary::BenchEngineAPIRequestSummary,
-    engine_api::{EngineApiRequest, EngineApiResponse, TimedEngineApiResponse},
-};
+use crate::engine_api::{EngineApiRequest, EngineApiResponse, TimedEngineApiResponse};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -35,7 +32,6 @@ pub struct JwtClient {
 
 impl JwtClient {
     pub fn new(secret: Vec<u8>, rpc_url: String) -> Self {
-
         Self {
             client: Client::new(),
             secret,
@@ -73,7 +69,7 @@ impl JwtClient {
         let start = std::time::Instant::now();
         let response = self
             .client
-            .post(&self.rpc_url) 
+            .post(&self.rpc_url)
             .header("Content-Type", "application/json")
             .header("Authorization", format!("Bearer {}", jwt))
             .body(request_string)

--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -23,37 +23,67 @@ async fn main() {
         header.push(client.cell().bold(true));
     }
 
-    for bench_input in bench_inputs.into_iter().progress() {
-        let mut column = Vec::new();
-        column.push(bench_input.name.clone().cell());
-        column.push(bench_input.description.clone().cell());
+    // Create a matrix to store results: [test_index][client_index]
+    let mut results = vec![vec![String::new(); get_clients().len()]; bench_inputs.len()];
 
-        for client in get_clients() {
-            let dc = docker::DockerCompose::new(&format!("{}.yml", client));
-            dc.up().unwrap();
+    let total_clients = get_clients().len();
 
-            // Wait for the client to be ready with a 30 second timeout
-            if let Err(e) = dc.wait_for_healthy(30).await {
-                eprintln!("Failed to start client {}: {}", client, e);
-                dc.down().unwrap();
-                continue;
-            }
+    // Outer loop over clients
+    for (client_idx, client) in get_clients().into_iter().enumerate() {
+        println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        println!(
+            "  Processing [{}/{}] {}",
+            client_idx + 1,
+            total_clients,
+            client
+        );
+        println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
 
+        println!("🐳 Starting docker container...");
+        let dc = docker::DockerCompose::new(&format!("{}.yml", client));
+        dc.up().unwrap();
+
+        println!("Waiting for client to be ready...");
+        // Wait for the client to be ready with a 30 second timeout
+        if let Err(e) = dc.wait_for_healthy(30).await {
+            eprintln!("Failed to start client {}: {}", client, e);
+            println!("Stopping docker container...");
+            dc.down().unwrap();
+            continue;
+        }
+        println!("Client is ready!");
+
+        // Inner loop over all benchmarks for this client
+        println!("Running benchmarks for {}...", client);
+        for (test_idx, bench_input) in bench_inputs.iter().enumerate().progress() {
             let summary = benchmark_engine_api_request(&bench_input).await;
 
-            // For each summary, we have a table column
+            // Store the result for this test and client
             for sum in summary {
                 let gas_used_u128 = parse_gas_used(&sum.gas_used);
                 let gas_per_second =
                     compute_gas_per_second(gas_used_u128, sum.time_taken_microseconds);
-
-                column.push(format_gas_rate(gas_per_second).cell());
+                results[test_idx][client_idx] = format_gas_rate(gas_per_second);
             }
-
-            dc.down().unwrap();
         }
 
-        rows.push(column);
+        println!("Stopping docker container for {}...", client);
+        dc.down().unwrap();
+    }
+
+    // Build the final table rows from the results matrix
+    for (idx, bench_input) in bench_inputs.iter().enumerate() {
+        let mut row = vec![
+            bench_input.name.clone().cell(),
+            bench_input.description.clone().cell(),
+        ];
+
+        // Add all client results for this test
+        for client_result in &results[idx] {
+            row.push(client_result.cell());
+        }
+
+        rows.push(row);
     }
 
     let table = rows.table().title(header).bold(true);


### PR DESCRIPTION
This PR introduces a series of optimizations to cut down the benchmarking time from `34m38s` to `2m3s` (~17x speedup) :

## 1. Health check for clients
Each client requires a varying amount of start up time. Previously the code used a 15 sec umbrella wait time for all clients. This was inefficient because most clients would startup quickly, this PR:

- Adds a health check that polls the Engine API endpoint until it responds
- Uses a configurable timeout (30 seconds) to avoid infinite waiting
- Includes error handling if the client fails to start
- Removes the fixed sleep delay
- Uses exponential backoff with 500ms intervals between health checks

## 2. Minimal docker restart
The PR minimizes docker restart when running multiple tests against a client. Each benchmark session however starts with a clean genesis state.