### PR TITLE
Fix: geth not loading genesis.json properly

### DIFF
--- a/config/genesis.json
+++ b/config/genesis.json
@@ -17,7 +17,6 @@
     "shanghaiTime": 0,
     "cancunTime": 0,
     "ethash": {},
-    "depositContractAddress": "0x4242424242424242424242424242424242424242",
     "blobSchedule": {
       "cancun": {
         "target": 3,

--- a/config/genesis.json
+++ b/config/genesis.json
@@ -16,7 +16,20 @@
     "terminalTotalDifficultyPassed": true,
     "shanghaiTime": 0,
     "cancunTime": 0,
-    "ethash": {}
+    "ethash": {},
+    "depositContractAddress": "0x4242424242424242424242424242424242424242",
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 6,
+        "max": 9,
+        "baseFeeUpdateFraction": 5007716
+      }
+    }
   },
   "alloc": {
     "0x0000000000000000000000000000000000000000": {


### PR DESCRIPTION
## Motivation

When launching the current testing environment, geth will fail with an error that it's the wrong fork number. This happens due to a missing parameter in the `genesis.json` file. This PR aimes to fix that.

## Changes

- Added `blobSchedule` field to the config in the `genesis.json` file.